### PR TITLE
adding support for private repos on travis pro

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,14 +12,13 @@ var which = require('which'),
     spawn = require('child_process').spawn,
     exec = require('child_process').exec,
     color = require('ansi-color').set,
+    https = require('https'),
+    readline = require('readline'),
     Travis = require('travis-ci'),
-    travis = new Travis({
-        version: '2.0.0'
-    }),
+    travis,
     good = color("✔", 'green'),
     bad = color("✖", 'red'),
     progress = color("♢", 'yellow');
-
 
 if (process.platform === 'win32') {
     good = color('OK', 'green');
@@ -141,9 +140,22 @@ var fetch = function(user, repo, branch, callback) {
 
 exports.fetch = fetch;
 
+var isPublicRepository = function (user, repo, callback) {
+    https.get('https://api.github.com/repos/' + user + '/' + repo, function (res) {
+        if (res.statusCode === 200) {
+            return callback(null, true);
+        } else if (res.statusCode === 404) {
+            return callback(null, false);
+        } else {
+            return callback('unknown');
+        }
+    });
+};
+
 exports.print = function(user, repo, branch, callback) {
     console.log('Fetching build status for', user + '/' + repo + ':' + branch);
-    fetch(user, repo, branch, function(err, data) {
+
+    var onFetch = function(err, data) {
         var status, commit, item;
 
         if (err) {
@@ -207,6 +219,47 @@ exports.print = function(user, repo, branch, callback) {
                 callback();
             }
         });
+    }
+
+
+    isPublicRepository(user, repo, function (err, repositoryIsPublic) {
+        if (err) {
+            return callback(err);
+        }
+
+        travis = new Travis({
+            version: '2.0.0',
+            pro: !repositoryIsPublic
+        });
+
+        if (repositoryIsPublic) {
+            fetch(user, repo, branch, onFetch);
+        } else {
+            console.log();
+            var rl = readline.createInterface({
+                input: process.stdin,
+                output: process.stdout
+            });
+            rl.question('username: ', function (username) {
+                rl.question('password: ', function (password) {
+                    rl.close();
+                    console.log();
+
+                    travis.authenticate({
+                        username: username,
+                        password: password
+                    }, function (err) {
+                        if (err) {
+                            return callback(err);
+                        }
+
+                        fetch(user, repo, branch, onFetch);
+                    });
+                });
+            });
+
+
+        }
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "Git sub command to show travis status",
     "version": "0.1.6",
     "dependencies": {
-        "travis-ci": "~0.1.2",
+        "travis-ci": "~1.0.0",
         "ansi-color": "*",
         "which": "*"
     },


### PR DESCRIPTION
Not sure if you have any interest in supporting travis pro accounts, but I've been using this locally for work stuff and its pretty handy. It just adds a check against the github api to see if the repo is public (no way to check with certainty if its private), and if its not, it prompts for the user's github credentials, and uses them to authenticate with travis.

``` bash
Fetching build status for pwmckenna/private-repo:master

username: pwmckenna
password: superSecret

    ✔ pwmckenna/private-repo
        Compare:  https://github.com/pwmckenna/private-repo/compare/cf14ef3361a1...7d86b1aaa404
        ✔ 7d8c621 (master) 1.0.0 (Patrick Williams <pwmckenna@gmail.com>) (passed)
            ✔ 39.1 node_js 0.10.1
```
